### PR TITLE
Add bubble-driven pin form and moderation controls

### DIFF
--- a/src/MapView.jsx
+++ b/src/MapView.jsx
@@ -7,8 +7,13 @@ const styleUrl = import.meta.env.VITE_MAPTILER_STYLE_URL;
 function MapView({ pins, onMapClick }) {
   const mapContainerRef = useRef(null);
   const mapRef = useRef(null);
+  const onMapClickRef = useRef(onMapClick);
   const [mapLoaded, setMapLoaded] = useState(false);
   const [mapError, setMapError] = useState(null);
+
+  useEffect(() => {
+    onMapClickRef.current = onMapClick;
+  }, [onMapClick]);
 
   useEffect(() => {
     if (!mapContainerRef.current || mapRef.current || !styleUrl) return;
@@ -52,8 +57,8 @@ function MapView({ pins, onMapClick }) {
     });
 
     map.on("click", (e) => {
-      if (onMapClick) {
-        onMapClick(e.lngLat);
+      if (onMapClickRef.current) {
+        onMapClickRef.current(e.lngLat);
       }
     });
 
@@ -62,7 +67,7 @@ function MapView({ pins, onMapClick }) {
       mapRef.current = null;
       setMapLoaded(false);
     };
-  }, [onMapClick]);
+  }, [styleUrl]);
 
   useEffect(() => {
     if (!mapLoaded) return;

--- a/src/bubbleOptions.js
+++ b/src/bubbleOptions.js
@@ -1,0 +1,106 @@
+import { supabase } from "./supabaseClient";
+
+const baseDefaultOptions = {
+  gender_identity: [
+    "Woman",
+    "Man",
+    "Nonbinary",
+    "Genderqueer",
+    "Trans woman",
+    "Trans man",
+    "Agender",
+  ],
+  seeking: [
+    "Women",
+    "Men",
+    "Nonbinary people",
+    "Queer folks",
+    "Friends",
+    "Play partners",
+    "Mentorship",
+  ],
+  interest_tags: [
+    "Rope",
+    "Impact",
+    "DS dynamics",
+    "Service",
+    "Switching",
+    "Sensory play",
+    "Workshops",
+  ],
+};
+
+const cloneOptions = (options) => ({
+  gender_identity: [...options.gender_identity],
+  seeking: [...options.seeking],
+  interest_tags: [...options.interest_tags],
+});
+
+export const defaultBubbleOptions = cloneOptions(baseDefaultOptions);
+
+export const getDefaultBubbleOptions = () => cloneOptions(baseDefaultOptions);
+
+export async function fetchBubbleOptions() {
+  const { data, error } = await supabase
+    .from("bubble_options")
+    .select("id, field, label")
+    .order("created_at", { ascending: true });
+
+  if (error || !data || data.length === 0) {
+    console.error("Falling back to default bubbles", error?.message);
+    return getDefaultBubbleOptions();
+  }
+
+  const options = {
+    gender_identity: [],
+    seeking: [],
+    interest_tags: [],
+  };
+
+  data.forEach((row) => {
+    if (options[row.field]) {
+      options[row.field].push(row.label);
+    }
+  });
+
+  return options;
+}
+
+export async function fetchBubbleOptionsWithIds() {
+  const { data, error } = await supabase
+    .from("bubble_options")
+    .select("id, field, label")
+    .order("created_at", { ascending: true });
+
+  if (error) throw error;
+  return data || [];
+}
+
+export async function addBubbleOption(field, label) {
+  const { data, error } = await supabase
+    .from("bubble_options")
+    .insert({ field, label })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function updateBubbleOption(id, label) {
+  const { data, error } = await supabase
+    .from("bubble_options")
+    .update({ label })
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function deleteBubbleOption(id) {
+  const { error } = await supabase.from("bubble_options").delete().eq("id", id);
+  if (error) throw error;
+  return true;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -159,6 +159,68 @@ textarea {
   color: #e5e7eb;
 }
 
+.label-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+  color: #e5e7eb;
+}
+
+.helper-text {
+  color: #9ca3af;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.bubble-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.35rem;
+}
+
+.bubble {
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.08);
+  color: #e5e7eb;
+  border-radius: 999px;
+  padding: 0.45rem 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 120ms ease, transform 120ms ease, border 120ms ease;
+}
+
+.bubble:hover {
+  transform: translateY(-1px);
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.bubble.selected {
+  background: #4f46e5;
+  border-color: #6366f1;
+  color: #fff;
+  box-shadow: 0 8px 20px rgba(99, 102, 241, 0.25);
+}
+
+.bubble.ghost {
+  background: transparent;
+  border-style: dashed;
+  color: #c7d2fe;
+}
+
+.bubble.add {
+  min-width: 48px;
+  justify-content: center;
+}
+
+.custom-row {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  align-items: center;
+}
+
 .helper {
   color: #9ca3af;
   font-size: 0.9rem;
@@ -242,6 +304,59 @@ textarea {
   align-items: center;
   gap: 0.5rem;
   color: #e5e7eb;
+}
+
+.bubble-moderation-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.bubble-moderation-column {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 0.85rem 0.95rem;
+  background: #f9fafb;
+}
+
+.small-chip {
+  background: #eef2ff;
+  color: #4338ca;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.bubble-editor-list {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.mod-bubble {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.mod-bubble .input {
+  flex: 1;
+  background: #fff;
+}
+
+.mod-bubble-actions {
+  display: flex;
+  gap: 0.45rem;
+}
+
+.ghost-button {
+  background: #e5e7eb;
+  color: #111827;
+  box-shadow: none;
+}
+
+.ghost-button:hover {
+  background: #d1d5db;
 }
 
 @media (max-width: 1080px) {


### PR DESCRIPTION
## Summary
- replace text inputs with selectable bubbles for gender, interested-in, and interests plus allow optional custom chips
- auto-fill city and country from map clicks while keeping the map view stable and removing the moderation link from the public page
- add moderation tools to manage bubble options with Supabase-backed add/edit/delete support and seeded defaults

## Testing
- Not run (npm command not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69336c913b548328b50afa2b6514c2e0)