### PR TITLE
Refine map layout and styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.86.2",
+        "lucide-react": "^0.556.0",
         "maplibre-gl": "^5.14.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -57,7 +58,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1603,7 +1603,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1663,7 +1662,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1769,7 +1767,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2010,7 +2007,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2593,6 +2589,14 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.556.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.556.0.tgz",
+      "integrity": "sha512-iOb8dRk7kLaYBZhR2VlV1CeJGxChBgUthpSP8wom9jfj79qovgG6qcSdiy6vkoREKPnbUYzJsCn4o4PtG3Iy+A==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/maplibre-gl": {
       "version": "5.14.0",
       "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.14.0.tgz",
@@ -2807,7 +2811,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2887,7 +2890,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2897,7 +2899,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3205,7 +3206,6 @@
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -3348,7 +3348,6 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.86.2",
+    "lucide-react": "^0.556.0",
     "maplibre-gl": "^5.14.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 :root {
-  color: #0b1021;
-  background-color: #f6f7fb;
+  color: #111827;
+  background-color: #ffffff;
   font-family: "Inter", "SF Pro Display", system-ui, -apple-system, BlinkMacSystemFont,
     "Segoe UI", sans-serif;
   line-height: 1.6;
@@ -8,10 +8,11 @@
 
 a {
   color: inherit;
+  text-decoration: none;
 }
 
 a:hover {
-  color: #4f46e5;
+  color: #2563eb;
 }
 
 * {
@@ -20,8 +21,8 @@ a:hover {
 
 body {
   margin: 0;
-  background: radial-gradient(circle at top left, #eef1ff 0, #f6f7fb 45%, #fdfdfd 100%);
-  color: #0b1021;
+  background: #ffffff;
+  color: #111827;
 }
 
 #root {
@@ -36,6 +37,7 @@ h5,
 h6 {
   margin: 0;
   font-weight: 700;
+  color: #0f172a;
 }
 
 p {
@@ -43,46 +45,80 @@ p {
 }
 
 button {
-  border: none;
+  border: 1px solid #d0d7e2;
   border-radius: 12px;
-  padding: 0.85rem 1rem;
+  padding: 0.75rem 1rem;
   font-size: 1rem;
   font-weight: 600;
   font-family: inherit;
   cursor: pointer;
-  background: #0f172a;
-  color: #fff;
-  transition: transform 120ms ease, box-shadow 180ms ease, background 120ms ease;
+  background: #ffffff;
+  color: #0f172a;
+  transition: transform 120ms ease, box-shadow 180ms ease, background 120ms ease,
+    border 120ms ease;
 }
 
 button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.18);
-  background: #111827;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  border-color: #c5cede;
 }
 
 button:disabled {
-  opacity: 0.7;
+  opacity: 0.6;
   cursor: not-allowed;
   transform: none;
   box-shadow: none;
 }
 
-.input {
+button.primary {
+  background: #2563eb;
+  color: #ffffff;
+  border-color: #1d4ed8;
+  box-shadow: 0 10px 30px rgba(37, 99, 235, 0.2);
+}
+
+button.primary:hover {
+  background: #1d4ed8;
+  border-color: #1e40af;
+}
+
+button.ghost {
+  background: #f3f4f6;
+  border-color: #e5e7eb;
+  color: #0f172a;
+  box-shadow: none;
+}
+
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  border: 1px solid #e5e7eb;
+  background: #ffffff;
+  color: #2563eb;
+}
+
+.input,
+textarea {
   width: 100%;
-  border: 1px solid #d9dce8;
+  border: 1px solid #e5e7eb;
   border-radius: 12px;
   padding: 0.85rem 0.95rem;
-  background: #fff;
+  background: #ffffff;
   font-size: 0.95rem;
   transition: border 100ms ease, box-shadow 100ms ease;
+  color: #0f172a;
 }
 
 .input:focus,
 textarea:focus {
   outline: none;
-  border-color: #4f46e5;
-  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.15);
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.16);
 }
 
 textarea {
@@ -90,175 +126,21 @@ textarea {
 }
 
 .app-shell {
-  display: grid;
-  grid-template-columns: 380px 1fr;
-  min-height: 100vh;
-  max-width: 1400px;
-  margin: 0 auto;
-  background: rgba(255, 255, 255, 0.85);
-  backdrop-filter: blur(8px);
-  box-shadow: 0 10px 40px rgba(15, 23, 42, 0.1);
-  border-radius: 24px;
-  overflow: hidden;
-}
-
-.sidebar {
-  background: linear-gradient(180deg, #0f172a 0%, #111827 100%);
-  color: #e5e7eb;
-  padding: 1.5rem 1.4rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.sidebar .muted {
-  color: #9ca3af;
-}
-
-.sidebar .link {
-  color: #a5b4fc;
-  font-weight: 600;
-}
-
-.badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.35rem 0.65rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  color: #e5e7eb;
-  font-size: 0.85rem;
-  font-weight: 600;
-}
-
-.panel {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 16px;
-  padding: 1rem 1.1rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
-}
-
-.panel h2 {
-  color: #fff;
-  font-size: 1.05rem;
-}
-
-.form-grid {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: #e5e7eb;
-}
-
-.label-heading {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.5rem;
-  color: #e5e7eb;
-}
-
-.helper-text {
-  color: #9ca3af;
-  font-size: 0.85rem;
-  font-weight: 500;
-}
-
-.bubble-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-top: 0.35rem;
-}
-
-.bubble {
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.08);
-  color: #e5e7eb;
-  border-radius: 999px;
-  padding: 0.45rem 0.8rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 120ms ease, transform 120ms ease, border 120ms ease;
-}
-
-.bubble:hover {
-  transform: translateY(-1px);
-  border-color: rgba(255, 255, 255, 0.35);
-}
-
-.bubble.selected {
-  background: #4f46e5;
-  border-color: #6366f1;
-  color: #fff;
-  box-shadow: 0 8px 20px rgba(99, 102, 241, 0.25);
-}
-
-.bubble.ghost {
-  background: transparent;
-  border-style: dashed;
-  color: #c7d2fe;
-}
-
-.bubble.add {
-  min-width: 48px;
-  justify-content: center;
-}
-
-.custom-row {
-  display: flex;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
-  align-items: center;
-}
-
-.helper {
-  color: #9ca3af;
-  font-size: 0.9rem;
-  margin-top: -0.35rem;
-}
-
-.status {
-  font-size: 0.9rem;
-  padding: 0.75rem 0.9rem;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.status.error {
-  color: #fecdd3;
-  background: rgba(248, 113, 113, 0.14);
-}
-
-.status.success {
-  color: #bbf7d0;
-  background: rgba(74, 222, 128, 0.14);
-}
-
-.map-region {
   position: relative;
-  background: #0b1021;
+  min-height: 100vh;
+  background: #ffffff;
+  color: #0f172a;
+  overflow: hidden;
 }
 
 .map-wrapper {
   position: relative;
-  height: 100%;
   min-height: 100vh;
 }
 
 .map-container {
   position: absolute;
   inset: 0;
-  border-left: 1px solid #e5e7eb;
 }
 
 .map-banner {
@@ -268,7 +150,7 @@ textarea {
   right: 16px;
   padding: 0.9rem 1rem;
   border-radius: 14px;
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.96);
   color: #0b1021;
   font-weight: 600;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
@@ -289,87 +171,322 @@ textarea {
   min-height: 100vh;
   padding: 2rem;
   color: #111827;
-  background: linear-gradient(135deg, #eef2ff 0%, #f8fafc 100%);
+  background: #f8fafc;
 }
 
-.meta {
+.title-card {
+  position: absolute;
+  top: 18px;
+  left: 18px;
   display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 18px;
+  padding: 1rem 1.1rem;
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.14);
+  max-width: 460px;
+  z-index: 5;
+}
+
+.title-row {
+  display: flex;
+  gap: 0.8rem;
   align-items: center;
-  gap: 0.6rem;
+}
+
+.title-icon {
+  color: #2563eb;
+  background: #e8f1ff;
+  padding: 0.6rem;
+  border-radius: 12px;
+}
+
+.title-meta {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.35rem;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background: #f3f4f6;
+  color: #0f172a;
+  font-size: 0.9rem;
+  font-weight: 600;
+  border: 1px solid #e5e7eb;
+}
+
+.pill.error {
+  background: #fef2f2;
+  color: #b91c1c;
+  border-color: #fecdd3;
+}
+
+.title-actions {
+  display: flex;
+  gap: 0.5rem;
   flex-wrap: wrap;
 }
 
-.section-title {
+.icon-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+  color: #0f172a;
+  padding: 0.55rem 0.85rem;
+}
+
+.icon-pill svg {
+  color: #2563eb;
+}
+
+.icon-pill.active {
+  background: #e5f0ff;
+  border-color: #c3ddff;
+  color: #1d4ed8;
+}
+
+.floating-panel {
+  position: absolute;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 18px;
+  box-shadow: 0 14px 50px rgba(15, 23, 42, 0.12);
+  width: min(440px, calc(100% - 32px));
+  z-index: 6;
+  overflow: hidden;
+}
+
+.floating-panel.side {
+  top: 150px;
+  left: 18px;
+  max-height: calc(100vh - 170px);
+}
+
+.floating-panel.bottom {
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: 18px;
+  width: calc(100% - 32px);
+  max-height: 70vh;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid #e5e7eb;
+  background: #f8fafc;
+}
+
+.panel-heading {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  color: #e5e7eb;
+  font-weight: 700;
+  color: #0f172a;
 }
 
-.bubble-moderation-grid {
+.panel-icon {
+  width: 32px;
+  height: 32px;
   display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  place-items: center;
+  border-radius: 10px;
+  background: #e8f1ff;
+  color: #2563eb;
 }
 
-.bubble-moderation-column {
+.panel-body {
+  padding: 1rem;
+  overflow-y: auto;
+  max-height: calc(100% - 56px);
+}
+
+.card {
   border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  padding: 0.95rem 1rem;
+  background: #ffffff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.muted {
+  color: #6b7280;
+}
+
+.muted-block {
+  background: #f7f8fb;
+}
+
+.list {
+  padding-left: 1.1rem;
+  margin: 0.25rem 0 0;
+  color: #374151;
+}
+
+.list li {
+  margin-bottom: 0.35rem;
+}
+
+.status-row {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: #374151;
+  font-weight: 600;
+}
+
+.form-grid {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.form-grid.compact {
+  gap: 0.8rem;
+  margin-top: 0.75rem;
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.label-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.helper-text {
+  color: #6b7280;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.bubble-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.35rem;
+}
+
+.bubble {
+  border: 1px solid #e5e7eb;
+  background: #f6f7fb;
+  color: #111827;
+  border-radius: 999px;
+  padding: 0.45rem 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 120ms ease, transform 120ms ease, border 120ms ease,
+    color 120ms ease;
+}
+
+.bubble:hover {
+  transform: translateY(-1px);
+  border-color: #cbd5e1;
+}
+
+.bubble.selected {
+  background: #2563eb;
+  border-color: #1d4ed8;
+  color: #ffffff;
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.22);
+}
+
+.bubble.ghost {
+  background: #ffffff;
+  border-style: dashed;
+  color: #1d4ed8;
+}
+
+.bubble.add {
+  min-width: 48px;
+  justify-content: center;
+}
+
+.custom-row {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  align-items: center;
+}
+
+.helper {
+  color: #6b7280;
+  font-size: 0.9rem;
+  margin-top: -0.15rem;
+}
+
+.status {
+  font-size: 0.9rem;
+  padding: 0.75rem 0.9rem;
   border-radius: 12px;
-  padding: 0.85rem 0.95rem;
+  border: 1px solid #e5e7eb;
   background: #f9fafb;
 }
 
-.small-chip {
-  background: #eef2ff;
-  color: #4338ca;
-  padding: 0.15rem 0.6rem;
-  border-radius: 999px;
-  font-size: 0.85rem;
+.status.error {
+  color: #b91c1c;
+  background: #fef2f2;
+  border-color: #fecdd3;
+}
+
+.status.success {
+  color: #065f46;
+  background: #ecfdf3;
+  border-color: #bbf7d0;
+}
+
+.filter-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.eyebrow {
+  font-size: 0.9rem;
   font-weight: 700;
+  letter-spacing: 0.01em;
+  color: #0f172a;
 }
 
-.bubble-editor-list {
-  display: grid;
-  gap: 0.6rem;
-}
-
-.mod-bubble {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-}
-
-.mod-bubble .input {
-  flex: 1;
-  background: #fff;
-}
-
-.mod-bubble-actions {
-  display: flex;
-  gap: 0.45rem;
-}
-
-.ghost-button {
-  background: #e5e7eb;
-  color: #111827;
-  box-shadow: none;
-}
-
-.ghost-button:hover {
-  background: #d1d5db;
-}
-
-@media (max-width: 1080px) {
-  .app-shell {
-    grid-template-columns: 1fr;
-    border-radius: 0;
+@media (max-width: 900px) {
+  .floating-panel.side {
+    top: auto;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: 18px;
+    width: calc(100% - 32px);
+    max-height: 75vh;
   }
 
-  .sidebar {
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  }
-
-  .map-container {
-    border-left: none;
+  .title-card {
+    max-width: calc(100% - 32px);
+    left: 50%;
+    transform: translateX(-50%);
   }
 }


### PR DESCRIPTION
## Summary
- restyle the app with a light theme, bright lucide icons, and a persistent title card for the Hair Fetish Map
- add overlay panels for info, pin submission, and filtering with clear navigation controls
- refresh bubble, form, and layout styling so panels adapt between side and bottom placements

## Testing
- not run (node version in container is below the package engines)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69345e9520608328a8eb94697721037c)