### PR TITLE
Align panels under title card on wide screens

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -188,36 +188,44 @@ textarea {
   background: #f8fafc;
 }
 
-.title-card {
+.overlay-rail {
   position: absolute;
   top: 18px;
   left: 18px;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  width: min(480px, calc(100% - 36px));
+  z-index: 6;
+}
+
+.title-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
   background: #ffffff;
   border: 1px solid #e5e7eb;
   border-radius: 18px;
-  padding: 1rem 1.1rem;
+  padding: 0.85rem 0.9rem;
   box-shadow: 0 12px 40px rgba(15, 23, 42, 0.14);
-  width: min(480px, calc(100% - 36px));
-  z-index: 5;
+  pointer-events: auto;
 }
 
 .title-row {
   display: flex;
-  gap: 0.8rem;
+  gap: 0.65rem;
   align-items: center;
+  justify-content: space-between;
 }
 
 .title-icon {
   color: #2563eb;
-  width: 1.6rem;
-  height: 1.6rem;
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 .title-text h1 {
-  font-size: 1.6rem;
+  font-size: 1.35rem;
 }
 
 .title-meta {
@@ -248,8 +256,9 @@ textarea {
 
 .title-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.4rem;
   flex-wrap: wrap;
+  width: 100%;
 }
 
 .icon-pill {
@@ -283,12 +292,15 @@ textarea {
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  pointer-events: auto;
 }
 
 .floating-panel.side {
-  top: 18px;
-  right: 18px;
-  max-height: calc(100vh - 36px);
+  position: relative;
+  top: auto;
+  right: auto;
+  max-height: none;
+  width: 100%;
 }
 
 .floating-panel.bottom {
@@ -516,19 +528,18 @@ textarea {
 }
 
 @media (max-width: 900px) {
-  .floating-panel.side {
-    top: auto;
+  .overlay-rail {
     left: 50%;
     transform: translateX(-50%);
-    bottom: 18px;
     width: calc(100% - 32px);
-    max-height: 75vh;
+    top: 18px;
   }
 
-  .title-card {
-    width: calc(100% - 32px);
+  .floating-panel.side {
+    position: absolute;
     left: 50%;
     transform: translateX(-50%);
-    right: 16px;
+    top: 120px;
+    max-height: 75vh;
   }
 }


### PR DESCRIPTION
## Summary
- reposition the info, add pin, and filter panels to sit beneath the title card on wide screens while compacting the title card layout
- move the pin counter into the info panel, remove duplicate section headers, and hide the continue button on wide add panels
- adjust mobile add-panel expansion to avoid overlapping the title card and tweak panel spacing

## Testing
- npm run build *(fails: npm not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69349eccd6488328bdbd94888041db5c)