### PR TITLE
Improve add pin panel layout and pending marker

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { CalendarClock, Filter, Info, MapPin, Plus, Scissors, X } from "lucide-react";
+import { CalendarClock, Filter, Info, Plus, Scissors, X } from "lucide-react";
 import { supabase } from "./supabaseClient";
 import MapView from "./MapView";
 import { fetchBubbleOptions, getDefaultBubbleOptions } from "./bubbleOptions";
@@ -477,12 +477,13 @@ function App() {
 
   const addPanelIntro = (
     <div className="panel-section">
-      <div className="status-row">
-        <MapPin size={18} />
-        <div className="location-stack">
-          <span className="eyebrow">Location</span>
-          <span className="location-strong">{locationLabel}</span>
-          <span className="muted small">{locationDetails}</span>
+      <div className="label location-label">
+        <div className="label-heading">
+          <span>Location</span>
+        </div>
+        <div className="location-chip-row">
+          <span className="location-chip">{locationLabel}</span>
+          <span className="location-chip subdued">{locationDetails}</span>
         </div>
       </div>
       {panelPlacement === "bottom" && !showFullAddForm && (
@@ -556,10 +557,6 @@ function App() {
               </div>
             </div>
           </div>
-
-          <p className="helper">
-            Location details are filled in automatically from where you click on the map.
-          </p>
 
           <label className="label">
             Nickname

--- a/src/MapView.jsx
+++ b/src/MapView.jsx
@@ -41,10 +41,10 @@ function MapView({ pins, onMapClick, pendingLocation, pendingIcon }) {
         type: "circle",
         source: "pins",
         paint: {
-          "circle-radius": 6,
-          "circle-color": "#ef4444",
+          "circle-radius": 13,
+          "circle-color": "#ffffff",
           "circle-stroke-width": 2,
-          "circle-stroke-color": "#f8fafc",
+          "circle-stroke-color": "#d1d5db",
         },
       });
 
@@ -55,11 +55,15 @@ function MapView({ pins, onMapClick, pendingLocation, pendingIcon }) {
         layout: {
           "text-field": ["coalesce", ["get", "icon"], "📍"],
           "text-size": 18,
-          "text-offset": [0, -0.8],
-          "text-anchor": "bottom",
+          "text-offset": [0, 0],
+          "text-anchor": "center",
+          "text-font": [
+            "Noto Color Emoji Regular",
+            "Open Sans Regular",
+            "Arial Unicode MS Regular",
+          ],
         },
         paint: {
-          "text-color": "#0f172a",
           "text-halo-color": "#ffffff",
           "text-halo-width": 1,
         },
@@ -75,10 +79,10 @@ function MapView({ pins, onMapClick, pendingLocation, pendingIcon }) {
         type: "circle",
         source: "pending-pin",
         paint: {
-          "circle-radius": 8,
-          "circle-color": "#111827",
+          "circle-radius": 14,
+          "circle-color": "#ffffff",
           "circle-stroke-width": 3,
-          "circle-stroke-color": "#22d3ee",
+          "circle-stroke-color": "#2563eb",
         },
       });
 
@@ -89,11 +93,15 @@ function MapView({ pins, onMapClick, pendingLocation, pendingIcon }) {
         layout: {
           "text-field": ["coalesce", ["get", "icon"], "📍"],
           "text-size": 18,
-          "text-offset": [0, -0.9],
-          "text-anchor": "bottom",
+          "text-offset": [0, 0],
+          "text-anchor": "center",
+          "text-font": [
+            "Noto Color Emoji Regular",
+            "Open Sans Regular",
+            "Arial Unicode MS Regular",
+          ],
         },
         paint: {
-          "text-color": "#0f172a",
           "text-halo-color": "#ffffff",
           "text-halo-width": 1,
         },

--- a/src/index.css
+++ b/src/index.css
@@ -302,6 +302,7 @@ textarea {
   display: flex;
   flex-direction: column;
   pointer-events: auto;
+  min-width: 0;
 }
 
 .floating-panel.side {
@@ -361,6 +362,8 @@ textarea {
   overflow-y: auto;
   overflow-x: hidden;
   flex: 1;
+  min-width: 0;
+  width: 100%;
 }
 
 .panel-body-wrapper {
@@ -368,6 +371,8 @@ textarea {
   display: flex;
   overflow-y: auto;
   overflow-x: hidden;
+  min-width: 0;
+  width: 100%;
 }
 
 .panel-body-wrapper.compact {
@@ -431,6 +436,7 @@ textarea {
 .form-grid {
   display: grid;
   gap: 0.9rem;
+  max-width: 100%;
 }
 
 .form-grid.compact {
@@ -465,6 +471,8 @@ textarea {
   flex-wrap: wrap;
   gap: 0.5rem;
   margin-top: 0.35rem;
+  width: 100%;
+  min-width: 0;
 }
 
 .bubble {
@@ -477,6 +485,10 @@ textarea {
   cursor: pointer;
   transition: background 120ms ease, transform 120ms ease, border 120ms ease,
     color 120ms ease;
+  max-width: 100%;
+  white-space: normal;
+  word-break: break-word;
+  text-align: left;
 }
 
 .bubble:hover {
@@ -531,9 +543,44 @@ textarea {
   color: #0f172a;
 }
 
+.location-label {
+  gap: 0.5rem;
+}
+
+.location-label .label-heading {
+  justify-content: flex-start;
+}
+
+.location-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.location-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid #e5e7eb;
+  background: #ffffff;
+  font-weight: 600;
+  color: #0f172a;
+  max-width: 100%;
+  word-break: break-word;
+}
+
+.location-chip.subdued {
+  background: #f1f5f9;
+  color: #374151;
+}
+
 .emoji-scroll {
   overflow-x: auto;
+  overflow-y: hidden;
   padding-bottom: 0.35rem;
+  max-width: 100%;
+  -webkit-overflow-scrolling: touch;
 }
 
 .emoji-grid {
@@ -543,6 +590,7 @@ textarea {
   grid-auto-columns: 56px;
   gap: 0.45rem;
   align-items: center;
+  width: max-content;
 }
 
 .emoji-chip {


### PR DESCRIPTION
## Summary
- wrap and constrain add panel form controls, add scrolling emoji picker, and restyle the location header with chips
- remove the automatic location helper text and align section titles to match other inputs
- restyle pending and approved map markers so the emoji is centered inside outlined circles

## Testing
- npm run lint *(fails: npm not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934ba9996b88328a6fb7ffd7b031500)