### PR TITLE
Fix Supabase policy definitions for compatibility

### DIFF
--- a/supabase/policies.sql
+++ b/supabase/policies.sql
@@ -3,7 +3,8 @@
 
 -- Pins policies
 -- Allow anonymous/public users to submit pins. They must remain pending and unapproved.
-create policy if not exists "Public users can submit pending pins" on public.pins
+drop policy if exists "Public users can submit pending pins" on public.pins;
+create policy "Public users can submit pending pins" on public.pins
   for insert to anon
   with check (
     status = 'pending'
@@ -11,24 +12,28 @@ create policy if not exists "Public users can submit pending pins" on public.pin
   );
 
 -- Allow public users to read only approved pins for the public map.
-create policy if not exists "Public users can read approved pins" on public.pins
+drop policy if exists "Public users can read approved pins" on public.pins;
+create policy "Public users can read approved pins" on public.pins
   for select to anon
   using (status = 'approved');
 
 -- Moderators (using the service role key) can update pin status and details for review.
-create policy if not exists "Moderators can manage pins" on public.pins
+drop policy if exists "Moderators can manage pins" on public.pins;
+create policy "Moderators can manage pins" on public.pins
   for all to service_role
   using (true)
   with check (true);
 
 -- Bubble option policies
 -- Public users can read available options to populate the form chips.
-create policy if not exists "Public users can read bubble options" on public.bubble_options
+drop policy if exists "Public users can read bubble options" on public.bubble_options;
+create policy "Public users can read bubble options" on public.bubble_options
   for select to anon
   using (true);
 
 -- Moderators (service role) manage bubble options from the moderation page.
-create policy if not exists "Moderators can manage bubble options" on public.bubble_options
+drop policy if exists "Moderators can manage bubble options" on public.bubble_options;
+create policy "Moderators can manage bubble options" on public.bubble_options
   for all to service_role
   using (true)
   with check (true);


### PR DESCRIPTION
## Summary
- replace unsupported `create policy if not exists` statements with drop/create pairs
- ensure policies can be rerun cleanly and apply correctly for anon and service roles

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934c16665948328b17d25b736ffe9d3)