### PR TITLE
Add moderator access policies and helper

### DIFF
--- a/supabase/moderator_access.sql
+++ b/supabase/moderator_access.sql
@@ -1,0 +1,33 @@
+-- Policies and helpers to allow authenticated moderators to use the moderation page
+-- Run after schema.sql and moderators.sql so the referenced tables exist.
+
+-- Helper function to check whether the current user is a moderator
+create or replace function public.is_moderator(uid uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1 from public.moderators m where m.user_id = uid
+  );
+$$;
+
+-- Allow authenticated moderators to manage pins for review
+alter table public.pins enable row level security;
+
+drop policy if exists "Authenticated moderators can manage pins" on public.pins;
+create policy "Authenticated moderators can manage pins" on public.pins
+  for all to authenticated
+  using (public.is_moderator(auth.uid()))
+  with check (public.is_moderator(auth.uid()));
+
+-- Allow authenticated moderators to manage bubble options
+alter table public.bubble_options enable row level security;
+
+drop policy if exists "Authenticated moderators can manage bubble options" on public.bubble_options;
+create policy "Authenticated moderators can manage bubble options" on public.bubble_options
+  for all to authenticated
+  using (public.is_moderator(auth.uid()))
+  with check (public.is_moderator(auth.uid()));


### PR DESCRIPTION
## Summary
- add helper function to check whether an authenticated user is a moderator
- allow authenticated moderators to manage pins via row-level security
- allow authenticated moderators to manage bubble options via row-level security

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934f279e41083289fd61d27840d519e)