### PR TITLE
Allow moderators to load submissions without service key

### DIFF
--- a/src/ModerationPage.jsx
+++ b/src/ModerationPage.jsx
@@ -8,8 +8,6 @@ import {
   updateBubbleOption,
 } from "./bubbleOptions";
 import { supabase, supabaseAdmin } from "./supabaseClient";
-
-const HAS_SERVICE_ROLE_KEY = Boolean(import.meta.env.VITE_SUPABASE_SERVICE_ROLE_KEY);
 const moderationClient = supabaseAdmin || supabase;
 
 function ModerationBubbleEditor({ option, field, onSave, onDelete }) {
@@ -108,7 +106,6 @@ function ModerationPage() {
   const [savingOption, setSavingOption] = useState(false);
   const defaultBubbleSet = useMemo(() => getDefaultBubbleOptions(), []);
   const [hasAccess, setHasAccess] = useState(false);
-  const [serviceRoleWarning, setServiceRoleWarning] = useState(null);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [authLoading, setAuthLoading] = useState(false);
@@ -208,12 +205,6 @@ function ModerationPage() {
 
   useEffect(() => {
     if (!hasAccess) return;
-    if (!HAS_SERVICE_ROLE_KEY) {
-      setServiceRoleWarning(
-        "Set VITE_SUPABASE_SERVICE_ROLE_KEY in your environment to load pending submissions for moderation."
-      );
-      return;
-    }
     fetchPins();
     refreshBubbleOptions();
   }, [fetchPins, hasAccess, refreshBubbleOptions]);
@@ -521,11 +512,6 @@ function ModerationPage() {
         </div>
 
         {error && <p style={{ color: "#b91c1c", margin: 0 }}>Error: {error}</p>}
-        {serviceRoleWarning && (
-          <p style={{ margin: 0, color: "#b45309", background: "#fef3c7", padding: "0.75rem 1rem", borderRadius: 12 }}>
-            {serviceRoleWarning}
-          </p>
-        )}
 
         {activeTab !== "bubbles" && activeTab !== "stats" && renderPins(pinGroups[activeTab])}
 


### PR DESCRIPTION
## Summary
- remove the environment gate that blocked moderation data without a service role key
- allow authenticated moderators to load pins and bubble options using the fallback Supabase client

## Testing
- npm run lint *(fails due to existing lint issues in other files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934f512800c8328bb4d91bc12768e0d)