### PR TITLE
Add rich pin labels and pin detail drawer

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -504,6 +504,58 @@ textarea {
   text-align: left;
 }
 
+.bubble-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.bubble.static {
+  cursor: default;
+  pointer-events: none;
+}
+
+.bubble.link-bubble {
+  pointer-events: auto;
+}
+
+.pin-panel .panel-icon {
+  font-size: 1.6rem;
+}
+
+.pin-panel .panel-title h3 {
+  line-height: 1.25;
+}
+
+.pin-subtitle {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.pin-panel-body {
+  padding-top: 0;
+}
+
+.pin-chip-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.35rem;
+}
+
+.pin-section {
+  display: grid;
+  gap: 0.35rem;
+  margin-top: 0.55rem;
+}
+
+.pin-note {
+  margin: 0;
+  color: #374151;
+  line-height: 1.5;
+}
+
 .bubble:hover {
   transform: translateY(-1px);
   border-color: #cbd5e1;

--- a/src/pinUtils.js
+++ b/src/pinUtils.js
@@ -1,0 +1,82 @@
+const GENDER_ABBREVIATIONS = {
+  man: "M",
+  male: "M",
+  m: "M",
+  woman: "F",
+  female: "F",
+  f: "F",
+  nonbinary: "NB",
+  "non-binary": "NB",
+  nb: "NB",
+  enby: "NB",
+  "trans masc": "TM",
+  "trans masculine": "TM",
+  "trans man": "TM",
+  "trans men": "TM",
+  tm: "TM",
+  "trans femme": "TF",
+  "trans feminine": "TF",
+  "trans woman": "TF",
+  "trans women": "TF",
+  tf: "TF",
+  trans: "T",
+};
+
+const normalize = (value) => value?.toString().trim().toLowerCase();
+
+export const getGenderAbbreviation = (genders, fallbackGender) => {
+  const list = Array.isArray(genders) ? genders : genders ? [genders] : [];
+  const candidates = [...list];
+  if (fallbackGender) candidates.push(fallbackGender);
+
+  for (const value of candidates) {
+    const key = normalize(value);
+    if (!key) continue;
+    const abbr = GENDER_ABBREVIATIONS[key];
+    if (abbr) return abbr;
+    if (key.startsWith("trans masc")) return "TM";
+    if (key.startsWith("trans fem") || key.startsWith("trans wom")) return "TF";
+  }
+
+  return "";
+};
+
+export const getGenderList = (genders, fallbackGender) => {
+  if (Array.isArray(genders) && genders.length > 0) return genders;
+  if (fallbackGender) return [fallbackGender];
+  return [];
+};
+
+const stripAt = (value) => value.replace(/^@/, "");
+const ensureProtocol = (value) =>
+  /^(https?:)?\/\//i.test(value) ? value : `https://${value}`;
+
+export const buildContactLink = (channel, rawValue) => {
+  const value = rawValue?.trim();
+  if (!value) return null;
+
+  switch (channel) {
+    case "Email":
+      return { label: channel, href: `mailto:${value}` };
+    case "Instagram":
+      return { label: channel, href: `https://instagram.com/${stripAt(value)}` };
+    case "X/Twitter":
+      return { label: channel, href: `https://twitter.com/${stripAt(value)}` };
+    case "Reddit": {
+      const handle = value.startsWith("u/") ? value : `u/${stripAt(value)}`;
+      return { label: channel, href: `https://reddit.com/${handle}` };
+    }
+    case "Discord":
+      return { label: channel, href: ensureProtocol(value) };
+    case "Tumblr":
+      return { label: channel, href: `https://${stripAt(value)}.tumblr.com` };
+    case "Youtube":
+      return { label: channel, href: ensureProtocol(value) };
+    case "Website":
+      return { label: channel, href: ensureProtocol(value) };
+    case "OnlyFans":
+      return { label: channel, href: `https://onlyfans.com/${stripAt(value)}` };
+    default:
+      return { label: channel, href: ensureProtocol(value) };
+  }
+};


### PR DESCRIPTION
## Summary
- enlarge emoji pins and add collision-aware labels with age/gender abbreviations
- introduce a responsive pin detail drawer showing demographics, interests, notes, and contact links
- add helpers for gender abbreviations and contact link formatting to support map labels and panels

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69350b7ecc38832895667940cc5bcd20)