### PR TITLE
Handle invalid contact method values

### DIFF
--- a/src/pinUtils.js
+++ b/src/pinUtils.js
@@ -52,7 +52,9 @@ const ensureProtocol = (value) =>
   /^(https?:)?\/\//i.test(value) ? value : `https://${value}`;
 
 export const buildContactLink = (channel, rawValue) => {
-  const value = rawValue?.trim();
+  if (typeof rawValue !== "string") return null;
+
+  const value = rawValue.trim();
   if (!value) return null;
 
   switch (channel) {


### PR DESCRIPTION
## Summary
- guard contact link building against non-string contact data to prevent runtime errors

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69350db5c30083288a7f9e109ca8eaba)