### PR TITLE
Improve filter inclusivity and add age range control

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -742,6 +742,23 @@ textarea {
   justify-content: flex-end;
 }
 
+.age-filter {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.age-slider-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.age-slider-row input[type="range"] {
+  flex: 1;
+}
+
 .eyebrow {
   font-size: 0.9rem;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- update gender and interested-in filters to support inclusive combinations that account for trans selections
- add an age range slider filter between the interested-in and interests sections and style it for single-line range display

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693512a662d883288142fdfe84d15367)