### PR TITLE
Fix interest approval callback initialization

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -641,6 +641,11 @@ function App() {
     return () => window.removeEventListener("resize", updateHeight);
   }, []);
 
+  const isInterestApproved = useCallback(
+    (label) => (bubbleStatusMap.interest_tags?.[label?.toLowerCase?.() || ""] || "approved") === "approved",
+    [bubbleStatusMap.interest_tags]
+  );
+
   const filteredPins = useMemo(() => {
     const matchesGenderSelection = (pin) => {
       if (filters.genders.length === 0) return true;
@@ -785,11 +790,6 @@ function App() {
       background: `linear-gradient(to right, #e5e7eb ${startPercent}%, #2563eb ${startPercent}%, #2563eb ${endPercent}%, #e5e7eb ${endPercent}%)`,
     };
   }, [filters.ageRange]);
-
-  const isInterestApproved = useCallback(
-    (label) => (bubbleStatusMap.interest_tags?.[label?.toLowerCase?.() || ""] || "approved") === "approved",
-    [bubbleStatusMap.interest_tags]
-  );
 
   const interestOptionsForForm = useMemo(() => {
     const selected = Array.isArray(form.interest_tags) ? form.interest_tags : [];


### PR DESCRIPTION
## Summary
- move the interest approval callback before it is used by the filter memo
- ensure pins can be filtered without triggering a ReferenceError

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69351eda68f483288a0da1a22e59fd9e)