### PR TITLE
Standardize panel typography and chip sizing

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,11 @@
   background-color: #ffffff;
   font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
   line-height: 1.6;
+  --font-family-base: "Inter", "Helvetica Neue", Arial, sans-serif;
+  --panel-title-size: 1.05rem;
+  --bubble-text-size: 0.95rem;
+  --subtext-size: 0.9rem;
+  --muted-text-color: #6b7280;
 }
 
 body,
@@ -12,7 +17,7 @@ textarea,
 select,
 .maplibregl-ctrl,
 .maplibregl-popup {
-  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+  font-family: var(--font-family-base);
 }
 
 a {
@@ -261,8 +266,8 @@ textarea {
   border-radius: 999px;
   background: #f3f4f6;
   color: #0f172a;
-  font-size: 0.9rem;
-  font-weight: 600;
+  font-size: var(--bubble-text-size);
+  font-weight: 500;
   border: 1px solid #e5e7eb;
 }
 
@@ -366,6 +371,11 @@ textarea {
   gap: 0.5rem;
 }
 
+.panel-title h3 {
+  font-size: var(--panel-title-size);
+  font-weight: 700;
+}
+
 .panel-body {
   padding: 0.25rem 1rem 1rem;
   overflow-y: auto;
@@ -403,6 +413,7 @@ textarea {
 .panel-lead {
   font-weight: 700;
   color: #0f172a;
+  font-size: var(--panel-title-size);
 }
 
 .card {
@@ -422,7 +433,8 @@ textarea {
 }
 
 .muted {
-  color: #6b7280;
+  color: var(--muted-text-color);
+  font-size: var(--subtext-size);
 }
 
 .muted-block {
@@ -469,8 +481,8 @@ textarea {
   gap: 0.25rem;
   width: 100%;
   min-width: 0;
-  font-size: 0.95rem;
-  font-weight: 600;
+  font-size: var(--panel-title-size);
+  font-weight: 700;
   color: #0f172a;
 }
 
@@ -482,8 +494,8 @@ textarea {
 }
 
 .helper-text {
-  color: #6b7280;
-  font-size: 0.85rem;
+  color: var(--muted-text-color);
+  font-size: var(--subtext-size);
   font-weight: 500;
 }
 
@@ -494,8 +506,8 @@ textarea {
 
 .subtle-footnote {
   margin: 0.35rem 0 0;
-  color: #4b5563;
-  font-size: 0.9rem;
+  color: var(--muted-text-color);
+  font-size: var(--subtext-size);
 }
 
 .bubble-grid {
@@ -514,7 +526,8 @@ textarea {
   color: #111827;
   border-radius: 999px;
   padding: 0.45rem 0.85rem;
-  font-weight: 600;
+  font-size: var(--bubble-text-size);
+  font-weight: 500;
   cursor: pointer;
   transition: background 120ms ease, transform 120ms ease, border 120ms ease,
     color 120ms ease;
@@ -549,8 +562,8 @@ textarea {
 
 .pin-subtitle {
   margin: 0;
-  color: #4b5563;
-  font-size: 0.95rem;
+  color: var(--muted-text-color);
+  font-size: var(--subtext-size);
 }
 
 .pin-panel-body {
@@ -607,14 +620,14 @@ textarea {
 }
 
 .helper {
-  color: #6b7280;
-  font-size: 0.9rem;
+  color: var(--muted-text-color);
+  font-size: var(--subtext-size);
   margin-top: -0.15rem;
 }
 
 .helper-text.small,
 .muted.small {
-  font-size: 0.85rem;
+  font-size: calc(var(--subtext-size) - 0.05rem);
 }
 
 .location-stack {
@@ -649,7 +662,8 @@ textarea {
   border-radius: 999px;
   border: 1px solid #e5e7eb;
   background: #ffffff;
-  font-weight: 600;
+  font-weight: 500;
+  font-size: var(--bubble-text-size);
   color: #0f172a;
   max-width: 100%;
   word-break: break-word;
@@ -833,7 +847,7 @@ textarea {
 }
 
 .eyebrow {
-  font-size: 0.9rem;
+  font-size: var(--panel-title-size);
   font-weight: 700;
   letter-spacing: 0.01em;
   color: #0f172a;
@@ -1104,8 +1118,8 @@ textarea {
   background: #e5e7eb;
   color: #0f172a;
   border-radius: 999px;
-  font-weight: 700;
-  font-size: 0.85rem;
+  font-weight: 500;
+  font-size: var(--bubble-text-size);
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary
- add shared typography variables to align panel headings and supporting text across the app
- reduce bubble and chip font weights while sizing them relative to section titles for consistency
- standardize hint and subtitle styling in a lighter grey for a unified design language

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69353b5e81d88328916e12c090de00b9)