### PR TITLE
Fix map pin interactions and label visibility

### DIFF
--- a/src/MapView.jsx
+++ b/src/MapView.jsx
@@ -203,8 +203,8 @@ function MapView({
           "text-offset": [1.2, 0],
           "text-max-width": 12,
           "text-optional": true,
-          "text-allow-overlap": false,
-          "text-ignore-placement": false,
+          "text-allow-overlap": true,
+          "text-ignore-placement": true,
           "symbol-sort-key": [
             "case",
             ["boolean", ["feature-state", "selected"], false],
@@ -285,6 +285,23 @@ function MapView({
     map.on("error", (evt) => {
       const message = evt?.error?.message || "Map could not load";
       setMapError(message);
+    });
+
+    const handlePinClick = (event) => {
+      const [target] = event.features || [];
+      if (target && onPinSelectRef.current) {
+        onPinSelectRef.current(target.properties);
+      }
+    };
+
+    ["pins-layer", "pins-emoji", "pin-labels"].forEach((layerId) => {
+      map.on("click", layerId, handlePinClick);
+      map.on("mouseenter", layerId, () =>
+        map.getCanvas().style.setProperty("cursor", "pointer")
+      );
+      map.on("mouseleave", layerId, () =>
+        map.getCanvas().style.removeProperty("cursor")
+      );
     });
 
     map.on("click", (e) => {


### PR DESCRIPTION
## Summary
- ensure pin labels are allowed to render even when placements overlap
- add dedicated click handlers and pointer cursor for pin layers to restore selection behavior

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69354256d3788328a9928f85bcdc09a8)