### PR TITLE
Improve map pin rendering and label handling

### DIFF
--- a/src/MapView.jsx
+++ b/src/MapView.jsx
@@ -152,6 +152,7 @@ function MapView({
     map.on("load", async () => {
       map.addSource("pins", {
         type: "geojson",
+        promoteId: "id",
         data: {
           type: "FeatureCollection",
           features: [],
@@ -182,7 +183,9 @@ function MapView({
         layout: {
           "icon-image": ["coalesce", ["get", "iconImageId"], emojiId(DEFAULT_EMOJI)],
           "icon-size": 0.68,
-          "icon-allow-overlap": true,
+          "icon-allow-overlap": false,
+          "icon-padding": 4,
+          "icon-optional": true,
         },
         paint: {
           "icon-halo-color": "#ffffff",
@@ -198,13 +201,25 @@ function MapView({
           "text-field": ["get", "labelText"],
           "text-size": 13,
           "text-font": ["Inter Regular", "Open Sans Regular", "Arial Unicode MS Regular"],
-          "text-variable-anchor": ["left", "right"],
+          "text-variable-anchor": [
+            "top",
+            "bottom",
+            "left",
+            "right",
+            "top-left",
+            "top-right",
+            "bottom-left",
+            "bottom-right",
+          ],
           "text-justify": "auto",
-          "text-offset": [1.2, 0],
+          "text-radial-offset": 1.1,
+          "text-offset": [0, 0],
           "text-max-width": 12,
           "text-optional": true,
-          "text-allow-overlap": true,
-          "text-ignore-placement": true,
+          "text-allow-overlap": false,
+          "text-ignore-placement": false,
+          "symbol-spacing": 12,
+          "symbol-avoid-edges": true,
           "symbol-sort-key": [
             "case",
             ["boolean", ["feature-state", "selected"], false],


### PR DESCRIPTION
## Summary
- ensure pin source tracks IDs for consistent feature state
- adjust emoji and label symbol layers to respect collision avoidance
- configure labels with dynamic anchors and spacing to keep nickname, age, and gender visible

## Testing
- npm run lint *(fails: existing lint issues in ModerationPage.jsx unrelated to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693543c51fec8328a12462ecfa4bea77)