### PR TITLE
Show all pin labels without collision hiding

### DIFF
--- a/src/MapView.jsx
+++ b/src/MapView.jsx
@@ -211,8 +211,9 @@ function MapView({
         layout: {
           "icon-image": ["coalesce", ["get", "iconImageId"], emojiId(DEFAULT_EMOJI)],
           "icon-size": 0.68,
-          "icon-allow-overlap": false,
-          "icon-padding": 4,
+          "icon-allow-overlap": true,
+          "icon-ignore-placement": true,
+          "icon-padding": 0,
           "icon-optional": true,
         },
         paint: {
@@ -244,10 +245,10 @@ function MapView({
           "text-offset": [0, 0],
           "text-max-width": 12,
           "text-optional": true,
-          "text-allow-overlap": false,
-          "text-ignore-placement": false,
-          "symbol-spacing": 12,
-          "symbol-avoid-edges": true,
+          "text-allow-overlap": true,
+          "text-ignore-placement": true,
+          "symbol-spacing": 1,
+          "symbol-avoid-edges": false,
           "symbol-sort-key": [
             "case",
             ["boolean", ["feature-state", "selected"], false],


### PR DESCRIPTION
## Summary
- allow pin emojis and labels to overlap so they always render, even in dense clusters
- keep pin click handlers intact so users can open pin details when selecting markers

## Testing
- npm run lint *(fails: existing React hook lint errors in App.jsx and ModerationPage.jsx)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693547b78298832882b9b2de2ecfa243)