### PR TITLE
Update gender display and interest ordering

### DIFF
--- a/src/bubbleOptions.js
+++ b/src/bubbleOptions.js
@@ -1,8 +1,8 @@
 import { supabase, supabaseAdmin } from "./supabaseClient";
 
 const baseDefaultOptions = {
-  gender_identity: ["Man", "Woman", "Nonbinary", "Trans"],
-  seeking: ["Man", "Woman", "Nonbinary", "Trans"],
+  gender_identity: ["Man", "Woman", "Non-binary", "Trans"],
+  seeking: ["Men", "Women", "Non-binary", "Trans"],
   interest_tags: [
     "Giving Haircuts",
     "Receiving Haircuts",


### PR DESCRIPTION
## Summary
- rename default gender and seeking bubble labels to non-binary/men/women and enforce pairing Trans with a base gender
- order interest bubbles by popularity while keeping initial interest view compact with a show-more toggle
- adjust gender abbreviations and pin info display so trans status is prefixed and women render as W

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935590ed6688328ab367b45567a1a2a)