### PR TITLE
Improve pin info bubble display and spacing

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -547,6 +547,8 @@ textarea {
   background: #f6f7fb;
   color: #111827;
   border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
   padding: 0.45rem 0.85rem;
   font-size: var(--chip-font-size);
   font-weight: var(--chip-font-weight);
@@ -578,9 +580,20 @@ textarea {
   font-size: 1.6rem;
 }
 
+.pin-panel .panel-top {
+  padding-bottom: 0.6rem;
+  margin-bottom: 0.35rem;
+}
+
+.pin-panel .panel-title {
+  align-items: center;
+}
+
 .pin-panel .panel-title h3 {
   line-height: 1.25;
   font-size: var(--section-title-size);
+  display: flex;
+  align-items: center;
 }
 
 .pin-subtitle {

--- a/src/pinUtils.js
+++ b/src/pinUtils.js
@@ -186,43 +186,63 @@ export const buildContactLink = (channel, rawValue) => {
 
   switch (channel) {
     case "Email":
-      return { label: channel, href: `mailto:${value}`, displayText: `Email: ${value}` };
+      return { label: channel, href: `mailto:${value}`, displayText: `mailto:${value}` };
     case "Instagram": {
       const handle = stripAt(value);
-      return { label: channel, href: `https://instagram.com/${handle}`, displayText: "Instagram" };
+      return {
+        label: channel,
+        href: `https://instagram.com/${handle}`,
+        displayText: `https://instagram.com/${handle}`,
+      };
     }
     case "X/Twitter": {
       const handle = stripAt(value);
-      return { label: channel, href: `https://twitter.com/${handle}`, displayText: "X/Twitter" };
+      return {
+        label: channel,
+        href: `https://twitter.com/${handle}`,
+        displayText: `https://twitter.com/${handle}`,
+      };
     }
     case "Reddit": {
       const handle = normalizeRedditHandle(value);
-      return { label: channel, href: `https://reddit.com/u/${handle}`, displayText: "Reddit" };
+      return {
+        label: channel,
+        href: `https://reddit.com/u/${handle}`,
+        displayText: `https://reddit.com/u/${handle}`,
+      };
     }
     case "Discord":
       return { label: channel, displayText: `Discord: ${value}` };
     case "Tumblr": {
       const handle = stripAt(value).replace(/\.tumblr\.com$/i, "");
-      return { label: channel, href: `https://${handle}.tumblr.com`, displayText: "Tumblr" };
+      return {
+        label: channel,
+        href: `https://${handle}.tumblr.com`,
+        displayText: `https://${handle}.tumblr.com`,
+      };
     }
     case "Youtube": {
       const { normalized } = isValidUrl(value);
       const href = normalized || ensureProtocol(value);
-      return { label: channel, href, displayText: "Youtube" };
+      return { label: channel, href, displayText: href };
     }
     case "Website": {
       const { normalized } = isValidUrl(value);
       const href = normalized || ensureProtocol(value);
-      return { label: channel, href, displayText: "Website" };
+      return { label: channel, href, displayText: href };
     }
     case "OnlyFans": {
       const handle = stripAt(value);
-      return { label: channel, href: `https://onlyfans.com/${handle}`, displayText: "OnlyFans" };
+      return {
+        label: channel,
+        href: `https://onlyfans.com/${handle}`,
+        displayText: `https://onlyfans.com/${handle}`,
+      };
     }
     default: {
       const { normalized } = isValidUrl(value);
       const href = normalized || ensureProtocol(value);
-      return { label: channel, href, displayText: channel };
+      return { label: channel, href, displayText: href };
     }
   }
 };


### PR DESCRIPTION
## Summary
- show the full generated contact links inside pin info bubbles
- align pin info bubbles with add-pin styling for consistent height and typography
- adjust pin detail header spacing and centering for the icon and nickname/title

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69355eb042908328a3f8b498a4c50319)