### PR TITLE
Update filters and contact options

### DIFF
--- a/src/bubbleOptions.js
+++ b/src/bubbleOptions.js
@@ -25,6 +25,7 @@ const baseDefaultOptions = {
     "Discord",
     "Reddit",
     "Instagram",
+    "Snapchat",
     "Tumblr",
     "X/Twitter",
     "Youtube",

--- a/src/pinUtils.js
+++ b/src/pinUtils.js
@@ -125,6 +125,17 @@ export const validateContactValue = (channel, rawValue) => {
         ? { valid: true, normalizedValue: result.normalized }
         : { valid: false, message: result.message };
     }
+    case "Snapchat": {
+      const result = validateFromPattern(
+        value,
+        /^[A-Za-z0-9._-]{3,15}$/,
+        "Enter a Snapchat username (3-15 characters).",
+        stripAt
+      );
+      return result.valid
+        ? { valid: true, normalizedValue: result.normalized }
+        : { valid: false, message: result.message };
+    }
     case "X/Twitter": {
       const result = validateFromPattern(
         value,
@@ -186,13 +197,21 @@ export const buildContactLink = (channel, rawValue) => {
 
   switch (channel) {
     case "Email":
-      return { label: channel, href: `mailto:${value}`, displayText: `mailto:${value}` };
+      return { label: channel, href: `mailto:${value}`, displayText: value };
     case "Instagram": {
       const handle = stripAt(value);
       return {
         label: channel,
         href: `https://instagram.com/${handle}`,
         displayText: `https://instagram.com/${handle}`,
+      };
+    }
+    case "Snapchat": {
+      const handle = stripAt(value);
+      return {
+        label: channel,
+        href: `https://www.snapchat.com/add/${handle}`,
+        displayText: `https://www.snapchat.com/add/${handle}`,
       };
     }
     case "X/Twitter": {


### PR DESCRIPTION
## Summary
- adjust filter panel copy and layout so age range label matches other sections
- reorder contact method options by popularity and add Snapchat support
- show email addresses without the `mailto:` prefix in pin contact details

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69356272c9c08328a32a88977df8e9d1)