### PR TITLE
Add moderation workflow for visitor feedback and pin reports

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1200,6 +1200,70 @@ textarea {
   margin-top: 0.35rem;
 }
 
+.tiny-button {
+  padding: 0.45rem 0.7rem;
+  border-radius: 10px;
+  font-size: 0.9rem;
+  border: 1px solid #e5e7eb;
+  background: #f3f4f6;
+  font-weight: 700;
+  box-shadow: none;
+}
+
+.tiny-button.subtle {
+  background: #ffffff;
+  color: #374151;
+  padding: 0.4rem 0.65rem;
+}
+
+.panel-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.feedback-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 50;
+}
+
+.feedback-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+.feedback-card {
+  position: relative;
+  width: min(520px, 100%);
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 1.1rem 1.25rem;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.18);
+  border: 1px solid #e5e7eb;
+  z-index: 1;
+}
+
+.feedback-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.feedback-subsection {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
 @media (max-width: 900px) {
   .overlay-rail {
     left: 50%;

--- a/supabase/moderator_access.sql
+++ b/supabase/moderator_access.sql
@@ -31,3 +31,12 @@ create policy "Authenticated moderators can manage bubble options" on public.bub
   for all to authenticated
   using (public.is_moderator(auth.uid()))
   with check (public.is_moderator(auth.uid()));
+
+-- Allow authenticated moderators to manage visitor messages
+alter table public.messages enable row level security;
+
+drop policy if exists "Authenticated moderators can manage messages" on public.messages;
+create policy "Authenticated moderators can manage messages" on public.messages
+  for all to authenticated
+  using (public.is_moderator(auth.uid()))
+  with check (public.is_moderator(auth.uid()));

--- a/supabase/policies.sql
+++ b/supabase/policies.sql
@@ -37,3 +37,18 @@ create policy "Moderators can manage bubble options" on public.bubble_options
   for all to service_role
   using (true)
   with check (true);
+
+-- Message/report policies
+drop policy if exists "Public users can submit messages" on public.messages;
+create policy "Public users can submit messages" on public.messages
+  for insert to anon
+  with check (
+    status = 'open'
+    and kind in ('site_feedback', 'pin_report')
+  );
+
+drop policy if exists "Moderators can manage messages" on public.messages;
+create policy "Moderators can manage messages" on public.messages
+  for all to service_role
+  using (true)
+  with check (true);


### PR DESCRIPTION
## Summary
- add a Supabase-backed messages table with policies for site feedback and pin reports
- add user-facing feedback/report prompts and buttons to share contact details with moderators
- add a moderation tab to review messages, view linked pins, and update statuses alongside existing queues

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936065f4bfc832880da6c3643cb3528)