### PR TITLE
Center and zoom map when selecting pin location

### DIFF
--- a/src/MapView.jsx
+++ b/src/MapView.jsx
@@ -9,6 +9,7 @@ const FEET_TO_METERS = 0.3048;
 const PENDING_RADIUS_FEET = 1500;
 const EARTH_RADIUS_METERS = 6378137;
 const CIRCLE_STEPS = 90;
+const MAP_CLICK_TARGET_ZOOM = 15.5;
 
 const toRadians = (degrees) => (degrees * Math.PI) / 180;
 const toDegrees = (radians) => (radians * 180) / Math.PI;
@@ -291,6 +292,12 @@ function MapView({
         }
         return;
       }
+
+      const zoomTarget = map.getZoom();
+      map.flyTo({
+        center: [e.lngLat.lng, e.lngLat.lat],
+        zoom: zoomTarget >= MAP_CLICK_TARGET_ZOOM ? zoomTarget : MAP_CLICK_TARGET_ZOOM,
+      });
 
       if (onMapClickRef.current) {
         onMapClickRef.current(e.lngLat);


### PR DESCRIPTION
## Summary
- recenter the map on placement clicks and animate to a ~1 km zoom level using map.flyTo
- keep existing pin selection behavior intact while centering on new pending pin locations

## Testing
- npm run lint *(fails: existing react-hooks rule violations already present in App.jsx and ModerationPage.jsx)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69361c9713d883289b64b56451c7a2cc)